### PR TITLE
Move the Mediawiker menu from the File menu to the Tools menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,6 +1,6 @@
 [
     {
-        "id": "file",
+        "id": "tools",
         "children":
         [
             {


### PR DESCRIPTION
This Move the Mediawiker menu from the File menu to the Tools menu, where all the other plugins live; it seems to make more sense there. This is certainly where I expect to find plugin related menu entries.
