### PR TITLE
fix list auto-continuation

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -44,7 +44,7 @@
         [
             { "key": "setting.mediawiker_is_here", "operand": true},
             { "key": "selector", "operator": "equal", "operand": "text.html.mediawiki", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[\\*\\#]\\s?\\S.*", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[*#]+\\s+.*", "match_all": true },
             { "key": "auto_complete_visible", "operator": "equal", "operand": false },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -44,7 +44,7 @@
         [
             { "key": "setting.mediawiker_is_here", "operand": true},
             { "key": "selector", "operator": "equal", "operand": "text.html.mediawiki", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[\\*\\#]\\s?\\S.*", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[*#]+\\s+.*", "match_all": true },
             { "key": "auto_complete_visible", "operator": "equal", "operand": false },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -44,7 +44,7 @@
         [
             { "key": "setting.mediawiker_is_here", "operand": true},
             { "key": "selector", "operator": "equal", "operand": "text.html.mediawiki", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[\\*\\#]\\s?\\S.*", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^[*#]+\\s+.*", "match_all": true },
             { "key": "auto_complete_visible", "operator": "equal", "operand": false },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]


### PR DESCRIPTION
Resolves issues with auto-continuation of lists when no space follows
the #/* symbols, caused by different match criteria in the regex patterns.