### PR TITLE
No Lua syntax for Module:* subpages (ex: Module:Test/doc)

### DIFF
--- a/mediawiker.py
+++ b/mediawiker.py
@@ -199,11 +199,6 @@ class MediawikerShowPageCommand(sublime_plugin.TextCommand):
             self.view.set_scratch(True)
             # own is_changed flag instead of is_dirty for possib. to reset..
             self.view.settings().set('is_changed', False)
-
-            isModule = re.match(r'^Module\:.*', title)
-            if isModule:
-                sublime.active_window().active_view().set_syntax_file('Packages/Lua/Lua.sublime-syntax')
-
         else:
             sublime.message_dialog('You have not rights to view this page.')
             self.view.close()

--- a/mediawiker.py
+++ b/mediawiker.py
@@ -200,6 +200,11 @@ class MediawikerShowPageCommand(sublime_plugin.TextCommand):
             self.view.set_scratch(True)
             # own is_changed flag instead of is_dirty for possib. to reset..
             self.view.settings().set('is_changed', False)
+
+            isModule = re.match(r'^Module\:.*', title)
+            if isModule:
+                sublime.active_window().active_view().set_syntax_file('Packages/Lua/Lua.sublime-syntax')
+
         else:
             sublime.message_dialog('You have not rights to view this page.')
             self.view.close()

--- a/mwutils.py
+++ b/mwutils.py
@@ -45,7 +45,7 @@ def set_setting(key, value):
 
 
 def set_syntax(title=None):
-    if title and title.startswith('Module:') and not title.find('/'):
+    if title and title.startswith('Module:') and not title.find('/doc'):
         # Scribunto lua modules
         if int(sublime.version()) >= 3084:  # dev build, or 3103 in main
             syntax = 'Packages/Lua/Lua.sublime-syntax'

--- a/mwutils.py
+++ b/mwutils.py
@@ -45,7 +45,7 @@ def set_setting(key, value):
 
 
 def set_syntax(title=None):
-    if title and title.startswith('Module:'):
+    if title and title.startswith('Module:') and not title.find('/'):
         # Scribunto lua modules
         if int(sublime.version()) >= 3084:  # dev build, or 3103 in main
             syntax = 'Packages/Lua/Lua.sublime-syntax'


### PR DESCRIPTION
Module pages are using Lua syntax but their subpages are not.
So we need to keep Mediawiki NG syntax for them.