### PR TITLE
Allow XML attributes without value

### DIFF
--- a/MediawikiNG.sublime-syntax
+++ b/MediawikiNG.sublime-syntax
@@ -7,7 +7,7 @@ scope: text.html.mediawiki
 
 variables:
   src_tag_before_lang: '((<)(source|syntaxhighlight)[ \t]+(lang)(=)("))'
-  src_tag_after_lang: '((")((\s+[^\"]+="[^\"]+")*)(>))'
+  src_tag_after_lang: '((")((\s+[^\"]+(="[^\"]+")?)*)(>))'
 
 contexts:
   main:


### PR DESCRIPTION
Although this is not a valid XML, the Mediawiki [docs](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight#line) actually
use this notation. Example

```xml
<syntaxhighlight lang="bash" line>
```

Since the XML standard is already ignored by enforcing "lang" as
the very first attribute, it seems OK to at least allow non-value
attributes after it.