### PR TITLE
Show name of current wiki alongside page name in input panel

### DIFF
--- a/mwcommands/mw_utils.py
+++ b/mwcommands/mw_utils.py
@@ -995,7 +995,7 @@ class InputPanelPageTitle(InputPanel):
             if not title_pre:
                 selection = self.window.active_view().sel()
                 title_pre = self.window.active_view().substr(selection[0]).strip()
-            self.show_input('Wiki page name:', title_pre)
+            self.show_input('Wiki page name ({}):'.format(get_view_site()), title_pre)
         else:
             self.on_done(title)
 
@@ -1003,7 +1003,8 @@ class InputPanelPageTitle(InputPanel):
         if title:
             pagename_cleared = pagename_clear(title)
             if title != pagename_cleared:
-                self.window.show_input_panel('Wiki page name:', pagename_cleared, self.on_done, self.on_change, None)
+                self.window.show_input_panel('Wiki page name ({}):'.format(get_view_site()),
+                                             pagename_cleared, self.on_done, self.on_change, None)
 
     def on_done(self, title):
         set_timeout_async(self.callback(title), 0)


### PR DESCRIPTION
This is another change I made to my local code a year ago, it helps a lot to see what site I'm currently opening a wiki page from when I have multiple wikis open at once